### PR TITLE
Set Composer's PHP version based on CI matrix version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,11 @@ jobs:
             ${{ runner.OS }}-${{ matrix.php-version }}-static-analysis-${{ hashFiles('**/composer.lock') }}-
             ${{ runner.OS }}-${{ matrix.php-version }}-static-analysis-
 
+      - name: "Update Composer platform version"
+        if: ${{ matrix.dependencies != 'locked' && matrix.php-version != '8.1' }}
+        shell: bash
+        run: "composer config platform.php ${{ matrix.php-version }}"
+
       - name: "Install dependencies"
         uses: ramsey/composer-install@v2
         with:


### PR DESCRIPTION
Enables testing against a wider dependency range, the platform version is only set to constrain Renovate to bumping dependency ranges to those supporting the minimum PHP version supported.