### PR TITLE
Changes for PHPUnit 11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,6 @@ jobs:
           - "highest"
           - "locked"
         php-version:
-          - "8.1"
           - "8.2"
           - "8.3"
 
@@ -53,7 +52,7 @@ jobs:
             ${{ runner.OS }}-${{ matrix.php-version }}-static-analysis-
 
       - name: "Update Composer platform version"
-        if: ${{ matrix.dependencies != 'locked' && matrix.php-version != '8.1' }}
+        if: ${{ matrix.dependencies != 'locked' && matrix.php-version != '8.2' }}
         shell: bash
         run: "composer config platform.php ${{ matrix.php-version }}"
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "phpunit/phpunit": "^11.1.1"
+        "phpunit/phpunit": "^11.1.2"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.42.0",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "phpunit/phpunit": "dev-main#b092517ed8afac69e44f0d10bfd89effe36d5a73"
+        "phpunit/phpunit": "^11.1.1"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.42.0",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "phpunit/phpunit": "^11.0"
+        "phpunit/phpunit": "dev-issue-5691/attributes-for-controlling-test-double-creation as 11.0.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.42.0",
@@ -33,6 +33,7 @@
         "psr-4": {
             "Tests\\Fixtures\\Lendable\\PHPUnitExtensions\\": "tests/fixtures/",
             "Tests\\Phpstan\\Lendable\\PHPUnitExtensions\\": "tests/phpstan/",
+            "Tests\\Rector\\Lendable\\PHPUnitExtensions\\": "tests/rector/",
             "Tests\\Unit\\Lendable\\PHPUnitExtensions\\": "tests/unit/"
         }
     },
@@ -65,6 +66,9 @@
         "phpunit:phpstan": [
             "phpunit --colors --testsuite=phpstan"
         ],
+        "phpunit:rector": [
+            "phpunit --colors --testsuite=rector"
+        ],
         "phpunit:unit": [
             "phpunit --colors --testsuite=unit"
         ],
@@ -82,7 +86,8 @@
         ],
         "tests": [
             "@tests:unit",
-            "@phpunit:phpstan"
+            "@phpunit:phpstan",
+            "@phpunit:rector"
         ],
         "tests:unit": [
             "@phpunit:unit"

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "phpunit/phpunit": "^10.4"
+        "php": "^8.2",
+        "phpunit/phpunit": "^11.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.41.1",
@@ -41,7 +41,7 @@
             "ergebnis/composer-normalize": true
         },
         "platform": {
-            "php": "8.1.26"
+            "php": "8.2.14"
         },
         "sort-packages": true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5892e740f309514c782c1e323a0cddc0",
+    "content-hash": "33635dd03fc96cbcb4e38095ff92c2ea",
     "packages": [
         {
             "name": "myclabs/deep-copy",
@@ -559,16 +559,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.0.2",
+            "version": "dev-issue-5691/attributes-for-controlling-test-double-creation",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "2f281e7e6776aea920cab5fc5a48d0fefbe1f39e"
+                "reference": "6c53031b9676e6733677784688b30f731ffdcfad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2f281e7e6776aea920cab5fc5a48d0fefbe1f39e",
-                "reference": "2f281e7e6776aea920cab5fc5a48d0fefbe1f39e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6c53031b9676e6733677784688b30f731ffdcfad",
+                "reference": "6c53031b9676e6733677784688b30f731ffdcfad",
                 "shasum": ""
             },
             "require": {
@@ -607,7 +607,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "11.0-dev"
+                    "dev-main": "11.1-dev"
                 }
             },
             "autoload": {
@@ -639,7 +639,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.0.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/issue-5691/attributes-for-controlling-test-double-creation"
             },
             "funding": [
                 {
@@ -655,7 +655,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-04T09:09:14+00:00"
+            "time": "2024-02-07T10:51:35+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -3321,9 +3321,18 @@
             "time": "2023-12-10T16:15:48+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "phpunit/phpunit",
+            "version": "dev-issue-5691/attributes-for-controlling-test-double-creation",
+            "alias": "11.0.0",
+            "alias_normalized": "11.0.0.0"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "phpunit/phpunit": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "770e080a14cf6efc67dae0901188e06a",
+    "content-hash": "bdbb83a0f4b0fb033520dd5d431f3c61",
     "packages": [
         {
             "name": "myclabs/deep-copy",
@@ -236,35 +236,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.11",
+            "version": "11.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "78c3b7625965c2513ee96569a4dbb62601784145"
+                "reference": "5e238e4b982cb272bf9faeee6f33af83d465d0e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/78c3b7625965c2513ee96569a4dbb62601784145",
-                "reference": "78c3b7625965c2513ee96569a4dbb62601784145",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5e238e4b982cb272bf9faeee6f33af83d465d0e2",
+                "reference": "5e238e4b982cb272bf9faeee6f33af83d465d0e2",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=8.1",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/php-text-template": "^3.0",
-                "sebastian/code-unit-reverse-lookup": "^3.0",
-                "sebastian/complexity": "^3.0",
-                "sebastian/environment": "^6.0",
-                "sebastian/lines-of-code": "^2.0",
-                "sebastian/version": "^4.0",
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.0",
+                "phpunit/php-text-template": "^4.0",
+                "sebastian/code-unit-reverse-lookup": "^4.0",
+                "sebastian/complexity": "^4.0",
+                "sebastian/environment": "^7.0",
+                "sebastian/lines-of-code": "^3.0",
+                "sebastian/version": "^5.0",
                 "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.1"
+                "phpunit/phpunit": "^11.0"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -273,7 +273,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "11.0-dev"
                 }
             },
             "autoload": {
@@ -302,7 +302,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.11"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.0"
             },
             "funding": [
                 {
@@ -310,32 +310,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-21T15:38:30+00:00"
+            "time": "2024-02-02T06:03:46+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "4.1.0",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+                "reference": "99e95c94ad9500daca992354fa09d7b99abe2210"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/99e95c94ad9500daca992354fa09d7b99abe2210",
+                "reference": "99e95c94ad9500daca992354fa09d7b99abe2210",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -363,7 +363,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -371,28 +371,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T06:24:48+00:00"
+            "time": "2024-02-02T06:05:04+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "4.0.0",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+                "reference": "5d8d9355a16d8cc5a1305b0a85342cfa420612be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5d8d9355a16d8cc5a1305b0a85342cfa420612be",
+                "reference": "5d8d9355a16d8cc5a1305b0a85342cfa420612be",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -400,7 +400,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -426,7 +426,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.0"
             },
             "funding": [
                 {
@@ -434,32 +435,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:56:09+00:00"
+            "time": "2024-02-02T06:05:50+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "3.0.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+                "reference": "d38f6cbff1cdb6f40b03c9811421561668cc133e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/d38f6cbff1cdb6f40b03c9811421561668cc133e",
+                "reference": "d38f6cbff1cdb6f40b03c9811421561668cc133e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -486,7 +487,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
                 "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.0"
             },
             "funding": [
                 {
@@ -494,32 +495,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T14:07:24+00:00"
+            "time": "2024-02-02T06:06:56+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "6.0.0",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+                "reference": "8a59d9e25720482ee7fcdf296595e08795b84dc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8a59d9e25720482ee7fcdf296595e08795b84dc5",
+                "reference": "8a59d9e25720482ee7fcdf296595e08795b84dc5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -545,7 +546,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.0"
             },
             "funding": [
                 {
@@ -553,20 +555,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:57:52+00:00"
+            "time": "2024-02-02T06:08:01+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.9",
+            "version": "11.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0bd663704f0165c9e76fe4f06ffa6a1ca727fdbe"
+                "reference": "2f281e7e6776aea920cab5fc5a48d0fefbe1f39e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0bd663704f0165c9e76fe4f06ffa6a1ca727fdbe",
-                "reference": "0bd663704f0165c9e76fe4f06ffa6a1ca727fdbe",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2f281e7e6776aea920cab5fc5a48d0fefbe1f39e",
+                "reference": "2f281e7e6776aea920cab5fc5a48d0fefbe1f39e",
                 "shasum": ""
             },
             "require": {
@@ -579,23 +581,22 @@
                 "myclabs/deep-copy": "^1.10.1",
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
-                "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.5",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/php-invoker": "^4.0",
-                "phpunit/php-text-template": "^3.0",
-                "phpunit/php-timer": "^6.0",
-                "sebastian/cli-parser": "^2.0",
-                "sebastian/code-unit": "^2.0",
-                "sebastian/comparator": "^5.0",
-                "sebastian/diff": "^5.0",
-                "sebastian/environment": "^6.0",
-                "sebastian/exporter": "^5.1",
-                "sebastian/global-state": "^6.0.1",
-                "sebastian/object-enumerator": "^5.0",
-                "sebastian/recursion-context": "^5.0",
-                "sebastian/type": "^4.0",
-                "sebastian/version": "^4.0"
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0",
+                "phpunit/php-file-iterator": "^5.0",
+                "phpunit/php-invoker": "^5.0",
+                "phpunit/php-text-template": "^4.0",
+                "phpunit/php-timer": "^7.0",
+                "sebastian/cli-parser": "^3.0",
+                "sebastian/code-unit": "^3.0",
+                "sebastian/comparator": "^6.0",
+                "sebastian/diff": "^6.0",
+                "sebastian/environment": "^7.0",
+                "sebastian/exporter": "^6.0",
+                "sebastian/global-state": "^7.0",
+                "sebastian/object-enumerator": "^6.0",
+                "sebastian/type": "^5.0",
+                "sebastian/version": "^5.0"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files"
@@ -606,7 +607,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.5-dev"
+                    "dev-main": "11.0-dev"
                 }
             },
             "autoload": {
@@ -638,7 +639,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.9"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.0.2"
             },
             "funding": [
                 {
@@ -654,32 +655,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-22T14:35:40+00:00"
+            "time": "2024-02-04T09:09:14+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae"
+                "reference": "efd6ce5bb8131fe981e2f879dbd47605fbe0cc6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/efdc130dbbbb8ef0b545a994fd811725c5282cae",
-                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/efd6ce5bb8131fe981e2f879dbd47605fbe0cc6f",
+                "reference": "efd6ce5bb8131fe981e2f879dbd47605fbe0cc6f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -702,7 +703,8 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.0"
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.0"
             },
             "funding": [
                 {
@@ -710,32 +712,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:58:15+00:00"
+            "time": "2024-02-02T05:48:04+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+                "reference": "6634549cb8d702282a04a774e36a7477d2bd9015"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/6634549cb8d702282a04a774e36a7477d2bd9015",
+                "reference": "6634549cb8d702282a04a774e36a7477d2bd9015",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -758,7 +760,8 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.0"
             },
             "funding": [
                 {
@@ -766,32 +769,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:58:43+00:00"
+            "time": "2024-02-02T05:50:41+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "3.0.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+                "reference": "df80c875d3e459b45c6039e4d9b71d4fbccae25d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/df80c875d3e459b45c6039e4d9b71d4fbccae25d",
+                "reference": "df80c875d3e459b45c6039e4d9b71d4fbccae25d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -813,7 +816,8 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.0"
             },
             "funding": [
                 {
@@ -821,36 +825,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:59:15+00:00"
+            "time": "2024-02-02T05:52:17+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2db5010a484d53ebf536087a70b4a5423c102372"
+                "reference": "bd0f2fa5b9257c69903537b266ccb80fcf940db8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2db5010a484d53ebf536087a70b4a5423c102372",
-                "reference": "2db5010a484d53ebf536087a70b4a5423c102372",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/bd0f2fa5b9257c69903537b266ccb80fcf940db8",
+                "reference": "bd0f2fa5b9257c69903537b266ccb80fcf940db8",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/diff": "^5.0",
-                "sebastian/exporter": "^5.0"
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -890,7 +894,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.0.0"
             },
             "funding": [
                 {
@@ -898,33 +902,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-14T13:18:12+00:00"
+            "time": "2024-02-02T05:53:45+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "3.2.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "68ff824baeae169ec9f2137158ee529584553799"
+                "reference": "88a434ad86150e11a606ac4866b09130712671f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
-                "reference": "68ff824baeae169ec9f2137158ee529584553799",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/88a434ad86150e11a606ac4866b09130712671f0",
+                "reference": "88a434ad86150e11a606ac4866b09130712671f0",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=8.1"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -948,7 +952,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
                 "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.0"
             },
             "funding": [
                 {
@@ -956,33 +960,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-21T08:37:17+00:00"
+            "time": "2024-02-02T05:55:19+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "5.1.0",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "fbf413a49e54f6b9b17e12d900ac7f6101591b7f"
+                "reference": "3e3f502419518897a923aa1c64d51f9def2e0aff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/fbf413a49e54f6b9b17e12d900ac7f6101591b7f",
-                "reference": "fbf413a49e54f6b9b17e12d900ac7f6101591b7f",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3e3f502419518897a923aa1c64d51f9def2e0aff",
+                "reference": "3e3f502419518897a923aa1c64d51f9def2e0aff",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0",
+                "phpunit/phpunit": "^11.0",
                 "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1015,7 +1019,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.0"
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.0"
             },
             "funding": [
                 {
@@ -1023,27 +1027,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T10:55:06+00:00"
+            "time": "2024-02-02T05:56:35+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "6.0.1",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951"
+                "reference": "100d8b855d7180f79f9a9a5c483f2d960581c3ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/43c751b41d74f96cbbd4e07b7aec9675651e2951",
-                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/100d8b855d7180f79f9a9a5c483f2d960581c3ea",
+                "reference": "100d8b855d7180f79f9a9a5c483f2d960581c3ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -1051,7 +1055,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -1079,7 +1083,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.0.0"
             },
             "funding": [
                 {
@@ -1087,34 +1091,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-11T05:39:26+00:00"
+            "time": "2024-02-02T05:57:54+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.1.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc"
+                "reference": "d0c0a93fc746b0c066037f1e7d09104129e868ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/64f51654862e0f5e318db7e9dcc2292c63cdbddc",
-                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d0c0a93fc746b0c066037f1e7d09104129e868ff",
+                "reference": "d0c0a93fc746b0c066037f1e7d09104129e868ff",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1157,7 +1161,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.1"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.0.0"
             },
             "funding": [
                 {
@@ -1165,35 +1169,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-24T13:22:09+00:00"
+            "time": "2024-02-02T05:58:52+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "6.0.1",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4"
+                "reference": "590e7cbc6565fa2e26c3df4e629a34bb0bc00c17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/7ea9ead78f6d380d2a667864c132c2f7b83055e4",
-                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/590e7cbc6565fa2e26c3df4e629a34bb0bc00c17",
+                "reference": "590e7cbc6565fa2e26c3df4e629a34bb0bc00c17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -1212,14 +1216,14 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.0"
             },
             "funding": [
                 {
@@ -1227,33 +1231,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-07-19T07:19:23+00:00"
+            "time": "2024-02-02T05:59:33+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "2.0.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
+                "reference": "376c5b3f6b43c78fdc049740bca76a7c846706c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
-                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/376c5b3f6b43c78fdc049740bca76a7c846706c0",
+                "reference": "376c5b3f6b43c78fdc049740bca76a7c846706c0",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=8.1"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1277,7 +1281,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.0"
             },
             "funding": [
                 {
@@ -1285,34 +1289,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-21T08:38:20+00:00"
+            "time": "2024-02-02T06:00:36+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "5.0.0",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+                "reference": "f75f6c460da0bbd9668f43a3dde0ec0ba7faa678"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f75f6c460da0bbd9668f43a3dde0ec0ba7faa678",
+                "reference": "f75f6c460da0bbd9668f43a3dde0ec0ba7faa678",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1334,7 +1338,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.0"
             },
             "funding": [
                 {
@@ -1342,32 +1347,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:08:32+00:00"
+            "time": "2024-02-02T06:01:29+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "3.0.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+                "reference": "bb2a6255d30853425fd38f032eb64ced9f7f132d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/bb2a6255d30853425fd38f032eb64ced9f7f132d",
+                "reference": "bb2a6255d30853425fd38f032eb64ced9f7f132d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1389,7 +1394,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.0"
             },
             "funding": [
                 {
@@ -1397,32 +1403,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:06:18+00:00"
+            "time": "2024-02-02T06:02:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "5.0.0",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
+                "reference": "b75224967b5a466925c6d54e68edd0edf8dd4ed4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
-                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b75224967b5a466925c6d54e68edd0edf8dd4ed4",
+                "reference": "b75224967b5a466925c6d54e68edd0edf8dd4ed4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1452,7 +1458,8 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.0"
             },
             "funding": [
                 {
@@ -1460,32 +1467,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:05:40+00:00"
+            "time": "2024-02-02T06:08:48+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "4.0.0",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+                "reference": "b8502785eb3523ca0dd4afe9ca62235590020f3f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8502785eb3523ca0dd4afe9ca62235590020f3f",
+                "reference": "b8502785eb3523ca0dd4afe9ca62235590020f3f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1508,7 +1515,8 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.0.0"
             },
             "funding": [
                 {
@@ -1516,29 +1524,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:10:45+00:00"
+            "time": "2024-02-02T06:09:34+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "4.0.1",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+                "reference": "13999475d2cb1ab33cb73403ba356a814fdbb001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/13999475d2cb1ab33cb73403ba356a814fdbb001",
+                "reference": "13999475d2cb1ab33cb73403ba356a814fdbb001",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1561,7 +1569,8 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.0"
             },
             "funding": [
                 {
@@ -1569,7 +1578,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-07T11:34:05+00:00"
+            "time": "2024-02-02T06:10:47+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -3323,11 +3332,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1"
+        "php": "^8.2"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.1.26"
+        "php": "8.2.14"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52247ae8afc0ac4e64cc7f92470318dd",
+    "content-hash": "f9e7b0d8ec6b53b04844bd1e230b9edf",
     "packages": [
         {
             "name": "myclabs/deep-copy",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f26193a8067c1ed1aef7e6942bf8650f",
+    "content-hash": "52247ae8afc0ac4e64cc7f92470318dd",
     "packages": [
         {
             "name": "myclabs/deep-copy",
@@ -566,16 +566,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "dev-main",
+            "version": "11.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b092517ed8afac69e44f0d10bfd89effe36d5a73"
+                "reference": "816cb6070af901c0548aa5f18f2132fd8a6e4ade"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b092517ed8afac69e44f0d10bfd89effe36d5a73",
-                "reference": "b092517ed8afac69e44f0d10bfd89effe36d5a73",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/816cb6070af901c0548aa5f18f2132fd8a6e4ade",
+                "reference": "816cb6070af901c0548aa5f18f2132fd8a6e4ade",
                 "shasum": ""
             },
             "require": {
@@ -608,7 +608,6 @@
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files"
             },
-            "default-branch": true,
             "bin": [
                 "phpunit"
             ],
@@ -647,7 +646,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/main"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.1.1"
             },
             "funding": [
                 {
@@ -663,7 +662,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-03T12:44:22+00:00"
+            "time": "2024-04-06T06:20:21+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -3319,9 +3318,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "phpunit/phpunit": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/phpstan/rules.neon
+++ b/phpstan/rules.neon
@@ -1,6 +1,8 @@
 conditionalTags:
   Lendable\PHPUnitExtensions\Phpstan\Rule\EnforceStrictMocking:
     phpstan.rules.rule: %lendable_phpunit.enforceStrictMocking.enabled%
+  Lendable\PHPUnitExtensions\Phpstan\Rule\ForbidLooseMock:
+    phpstan.rules.rule: %lendable_phpunit.enforceStrictMocking.enabled%
 
 parametersSchema:
   lendable_phpunit: structure([
@@ -21,3 +23,5 @@ services:
     class: Lendable\PHPUnitExtensions\Phpstan\Rule\EnforceStrictMocking
     arguments:
       pardoned: %lendable_phpunit.enforceStrictMocking.pardoned%
+  -
+    class: Lendable\PHPUnitExtensions\Phpstan\Rule\ForbidLooseMock

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,5 +21,8 @@
             <directory>./tests/phpstan/</directory>
             <exclude>./tests/phpstan/data/</exclude>
         </testsuite>
+        <testsuite name="rector">
+            <directory>./tests/rector/</directory>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Phpstan/Rule/EnforceStrictMocking.php
+++ b/src/Phpstan/Rule/EnforceStrictMocking.php
@@ -13,6 +13,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPUnit\Framework\Attributes\DisableReturnValueGenerationForTestDoubles;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -68,6 +69,10 @@ final class EnforceStrictMocking implements Rule
 
         $parents = $reflection->getParentClassesNames();
         if (!\in_array(TestCase::class, $parents, true)) {
+            return [];
+        }
+
+        if (\count($reflection->getNativeReflection()->getAttributes(DisableReturnValueGenerationForTestDoubles::class)) > 0) {
             return [];
         }
 

--- a/src/Phpstan/Rule/EnforceStrictMocking.php
+++ b/src/Phpstan/Rule/EnforceStrictMocking.php
@@ -79,13 +79,13 @@ final class EnforceStrictMocking implements Rule
             return [];
         }
 
-        $ruleErrorBuilder = RuleErrorBuilder::message(\sprintf(
-            'Class "%s" must either extend "%s" or use "%s" trait.',
-            $className,
-            StrictMockingTestCase::class,
-            StrictMockingTrait::class,
-        ));
-
-        return [$ruleErrorBuilder->build()];
+        return [
+            RuleErrorBuilder::message(\sprintf(
+                'Class "%s" must either extend "%s" or use "%s" trait.',
+                $className,
+                StrictMockingTestCase::class,
+                StrictMockingTrait::class,
+            ))->build(),
+        ];
     }
 }

--- a/src/Phpstan/Rule/EnforceStrictMocking.php
+++ b/src/Phpstan/Rule/EnforceStrictMocking.php
@@ -72,7 +72,7 @@ final class EnforceStrictMocking implements Rule
             return [];
         }
 
-        if (\count($reflection->getNativeReflection()->getAttributes(DisableReturnValueGenerationForTestDoubles::class)) > 0) {
+        if ($reflection->getNativeReflection()->getAttributes(DisableReturnValueGenerationForTestDoubles::class) !== []) {
             return [];
         }
 

--- a/src/Phpstan/Rule/ForbidLooseMock.php
+++ b/src/Phpstan/Rule/ForbidLooseMock.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lendable\PHPUnitExtensions\Phpstan\Rule;
+
+use Lendable\PHPUnitExtensions\StrictMocking as StrictMockingTrait;
+use Lendable\PHPUnitExtensions\TestCase as StrictMockingTestCase;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @implements Rule<MethodCall>
+ */
+final readonly class ForbidLooseMock implements Rule
+{
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        if (!$scope->isInClass()) {
+            return [];
+        }
+
+        if ($node->name->toString() !== 'createMock') {
+            return [];
+        }
+
+        $reflection = $scope->getClassReflection();
+        $parents = $reflection->getParentClassesNames();
+        if (!\in_array(TestCase::class, $parents, true)) {
+            return [];
+        }
+
+        if (
+            !\in_array(StrictMockingTestCase::class, $parents, true)
+            && !isset($reflection->getTraits(true)[StrictMockingTrait::class])
+        ) {
+            return [];
+        }
+
+        return [RuleErrorBuilder::message('Forbidden call to "createMock", use "createStrictMock" instead.')->build()];
+    }
+}

--- a/src/Rector/EnforceDisableReturnValueGenerationForTestDoublesRector.php
+++ b/src/Rector/EnforceDisableReturnValueGenerationForTestDoublesRector.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lendable\PHPUnitExtensions\Rector;
 
 use PhpParser\Node;
@@ -18,8 +20,7 @@ final class EnforceDisableReturnValueGenerationForTestDoublesRector extends Abst
         private readonly PhpAttributeAnalyzer $attributeAnalyzer,
         private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
         private readonly PhpAttributeGroupFactory $attributeGroupFactory,
-    ) {
-    }
+    ) {}
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -28,24 +29,24 @@ final class EnforceDisableReturnValueGenerationForTestDoublesRector extends Abst
             [
                 new CodeSample(
                     <<<'CODE_SAMPLE'
-namespace Tests\Foo;
+                        namespace Tests\Foo;
 
-use PHPUnit\Framework\TestCase;
+                        use PHPUnit\Framework\TestCase;
 
-class FooTest extends TestCase {
-}
-CODE_SAMPLE
-                    , <<<'CODE_SAMPLE'
-namespace Tests\Foo;
+                        class FooTest extends TestCase {
+                        }
+                        CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+                        namespace Tests\Foo;
 
-use PHPUnit\Framework\TestCase;
+                        use PHPUnit\Framework\TestCase;
 
-#[\PHPUnit\Framework\Attributes\DisableReturnValueGenerationForTestDoubles]
-class FooTest extends TestCase {
-}
-CODE_SAMPLE
+                        #[\PHPUnit\Framework\Attributes\DisableReturnValueGenerationForTestDoubles]
+                        class FooTest extends TestCase {
+                        }
+                        CODE_SAMPLE
                 ),
-            ]
+            ],
         );
     }
 
@@ -54,11 +55,9 @@ CODE_SAMPLE
         return [Class_::class];
     }
 
-    /**
-     * @param Class_ $node
-     */
     public function refactor(Node $node): ?Class_
     {
+        /** @var Class_ $node */
         if (!$this->testsNodeAnalyzer->isInTestClass($node)) {
             return null;
         }

--- a/src/Rector/EnforceDisableReturnValueGenerationForTestDoublesRector.php
+++ b/src/Rector/EnforceDisableReturnValueGenerationForTestDoublesRector.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Lendable\PHPUnitExtensions\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PHPUnit\Framework\Attributes\DisableReturnValueGenerationForTestDoubles;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
+use Rector\PHPUnit\NodeAnalyzer\TestsNodeAnalyzer;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class EnforceDisableReturnValueGenerationForTestDoublesRector extends AbstractRector
+{
+    public function __construct(
+        private readonly PhpAttributeAnalyzer $attributeAnalyzer,
+        private readonly TestsNodeAnalyzer $testsNodeAnalyzer,
+        private readonly PhpAttributeGroupFactory $attributeGroupFactory,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add the `DisableReturnValueGenerationForTestDoubles` attribute to test cases',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+namespace Tests\Foo;
+
+use PHPUnit\Framework\TestCase;
+
+class FooTest extends TestCase {
+}
+CODE_SAMPLE
+                    , <<<'CODE_SAMPLE'
+namespace Tests\Foo;
+
+use PHPUnit\Framework\TestCase;
+
+#[\PHPUnit\Framework\Attributes\DisableReturnValueGenerationForTestDoubles]
+class FooTest extends TestCase {
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function refactor(Node $node): ?Class_
+    {
+        if (!$this->testsNodeAnalyzer->isInTestClass($node)) {
+            return null;
+        }
+
+        if ($this->attributeAnalyzer->hasPhpAttribute($node, DisableReturnValueGenerationForTestDoubles::class)) {
+            return null;
+        }
+
+        $node->attrGroups[] = $this->attributeGroupFactory->createFromClass(DisableReturnValueGenerationForTestDoubles::class);
+
+        return $node;
+    }
+}

--- a/src/StrictMocking.php
+++ b/src/StrictMocking.php
@@ -14,10 +14,18 @@ use PHPUnit\Framework\TestCase;
  */
 trait StrictMocking
 {
-    final protected function createMock(string $originalClassName): MockObject
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $originalClassName
+     *
+     * @return MockObject&T
+     */
+    final protected function createStrictMock(string $originalClassName): MockObject
     {
         $mock = (new MockObjectGenerator())->testDouble(
             $originalClassName,
+            true,
             true,
             callOriginalConstructor: false,
             callOriginalClone: false,

--- a/tests/fixtures/ExampleTestCase.php
+++ b/tests/fixtures/ExampleTestCase.php
@@ -10,7 +10,7 @@ final class ExampleTestCase extends TestCase
 {
     public function exerciseMockCreationWithoutMethodsConfigured(): void
     {
-        $mock = $this->createMock(ExampleInterface::class);
+        $mock = $this->createStrictMock(ExampleInterface::class);
 
         $mock->foo();
     }

--- a/tests/phpstan/Rule/EnforceExtendedClassTest.php
+++ b/tests/phpstan/Rule/EnforceExtendedClassTest.php
@@ -22,7 +22,7 @@ final class EnforceExtendedClassTest extends RuleTestCase
         $this->analyse([__DIR__.'/../data/TestCaseTest.php'], [
             [
                 $this->errorMessageFor(TestCaseTest::class),
-                9,
+                10,
             ],
         ]);
     }
@@ -39,7 +39,7 @@ final class EnforceExtendedClassTest extends RuleTestCase
         $this->analyse([__DIR__.'/../data/IndirectlyExtendingTest.php'], [
             [
                 $this->errorMessageFor(IndirectlyExtendingTest::class),
-                7,
+                9,
             ],
         ]);
     }

--- a/tests/phpstan/Rule/ForbidLooseMockTest.php
+++ b/tests/phpstan/Rule/ForbidLooseMockTest.php
@@ -57,6 +57,12 @@ final class ForbidLooseMockTest extends RuleTestCase
         $this->analyse([__DIR__.'/../data/TestCaseTest.php'], []);
     }
 
+    #[Test]
+    public function does_not_report_test_using_disabling_of_return_value_generation_attribute(): void
+    {
+        $this->analyse([__DIR__.'/../data/TestCaseWithAttributeTest.php'], []);
+    }
+
     protected function getRule(): ForbidLooseMock
     {
         return new ForbidLooseMock();

--- a/tests/phpstan/Rule/ForbidLooseMockTest.php
+++ b/tests/phpstan/Rule/ForbidLooseMockTest.php
@@ -35,6 +35,17 @@ final class ForbidLooseMockTest extends RuleTestCase
     }
 
     #[Test]
+    public function reports_strict_mocking_test_case_with_a_test_coming_from_a_trait(): void
+    {
+        $this->analyse([__DIR__.'/../data/TestThroughTraitTest.php', __DIR__.'/../data/TraitWithTest.php'], [
+            [
+                'Forbidden call to "createMock", use "createStrictMock" instead.',
+                14,
+            ],
+        ]);
+    }
+
+    #[Test]
     public function does_not_report_non_strict_mocking_test_case(): void
     {
         $this->analyse([__DIR__.'/../data/TestCaseTest.php'], []);

--- a/tests/phpstan/Rule/ForbidLooseMockTest.php
+++ b/tests/phpstan/Rule/ForbidLooseMockTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Phpstan\Lendable\PHPUnitExtensions\Rule;
+
+use Lendable\PHPUnitExtensions\Phpstan\Rule\ForbidLooseMock;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(ForbidLooseMock::class)]
+final class ForbidLooseMockTest extends RuleTestCase
+{
+    #[Test]
+    public function reports_strict_test_case(): void
+    {
+        $this->analyse([__DIR__.'/../data/StrictMockingTestCaseTest.php'], [
+            [
+                'Forbidden call to "createMock", use "createStrictMock" instead.',
+                15,
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function reports_strict_mocking_test_case_using_trait(): void
+    {
+        $this->analyse([__DIR__.'/../data/StrictMockingTraitTest.php'], [
+            [
+                'Forbidden call to "createMock", use "createStrictMock" instead.',
+                18,
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function does_not_report_non_strict_mocking_test_case(): void
+    {
+        $this->analyse([__DIR__.'/../data/TestCaseTest.php'], []);
+    }
+
+    #[Test]
+    public function does_not_report_test_indirectly_extending_phpunits_test_case(): void
+    {
+        $this->analyse([__DIR__.'/../data/TestCaseTest.php'], []);
+    }
+
+    protected function getRule(): ForbidLooseMock
+    {
+        return new ForbidLooseMock();
+    }
+}

--- a/tests/phpstan/data/IndirectStrictMockingTraitTest.php
+++ b/tests/phpstan/data/IndirectStrictMockingTraitTest.php
@@ -4,4 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Phpstan\Lendable\PHPUnitExtensions\data;
 
-final class IndirectStrictMockingTraitTest extends StrictMockingTraitTest {}
+use PHPUnit\Framework\Attributes\Test;
+
+final class IndirectStrictMockingTraitTest extends StrictMockingTraitTest
+{
+    #[Test]
+    public function loose_mock(): void
+    {
+        $this->createMock(\ArrayAccess::class);
+        $this->createStrictMock(\ArrayAccess::class);
+    }
+}

--- a/tests/phpstan/data/IndirectlyExtendingTest.php
+++ b/tests/phpstan/data/IndirectlyExtendingTest.php
@@ -4,4 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Phpstan\Lendable\PHPUnitExtensions\data;
 
-class IndirectlyExtendingTest extends TestCaseTest {}
+use PHPUnit\Framework\Attributes\Test;
+
+class IndirectlyExtendingTest extends TestCaseTest
+{
+    #[Test]
+    public function loose_mock(): void
+    {
+        $this->createMock(\ArrayAccess::class);
+    }
+}

--- a/tests/phpstan/data/StrictMockingTestCaseTest.php
+++ b/tests/phpstan/data/StrictMockingTestCaseTest.php
@@ -5,5 +5,14 @@ declare(strict_types=1);
 namespace Tests\Phpstan\Lendable\PHPUnitExtensions\data;
 
 use Lendable\PHPUnitExtensions\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
-final class StrictMockingTestCaseTest extends TestCase {}
+final class StrictMockingTestCaseTest extends TestCase
+{
+    #[Test]
+    public function loose_mock(): void
+    {
+        $this->createMock(\ArrayAccess::class);
+        $this->createStrictMock(\ArrayAccess::class);
+    }
+}

--- a/tests/phpstan/data/StrictMockingTraitTest.php
+++ b/tests/phpstan/data/StrictMockingTraitTest.php
@@ -5,9 +5,17 @@ declare(strict_types=1);
 namespace Tests\Phpstan\Lendable\PHPUnitExtensions\data;
 
 use Lendable\PHPUnitExtensions\StrictMocking;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class StrictMockingTraitTest extends TestCase
 {
     use StrictMocking;
+
+    #[Test]
+    public function loose_mock(): void
+    {
+        $this->createMock(\ArrayAccess::class);
+        $this->createStrictMock(\ArrayAccess::class);
+    }
 }

--- a/tests/phpstan/data/TestCaseTest.php
+++ b/tests/phpstan/data/TestCaseTest.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Phpstan\Lendable\PHPUnitExtensions\data;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-class TestCaseTest extends TestCase {}
+class TestCaseTest extends TestCase
+{
+    #[Test]
+    public function loose_mock(): void
+    {
+        $this->createMock(\ArrayAccess::class);
+    }
+}

--- a/tests/phpstan/data/TestCaseWithAttributeTest.php
+++ b/tests/phpstan/data/TestCaseWithAttributeTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Phpstan\Lendable\PHPUnitExtensions\data;
+
+use PHPUnit\Framework\Attributes\DisableReturnValueGenerationForTestDoubles;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[DisableReturnValueGenerationForTestDoubles]
+class TestCaseWithAttributeTest extends TestCase
+{
+    #[Test]
+    public function loose_mock(): void
+    {
+        $this->createMock(\ArrayAccess::class);
+    }
+}

--- a/tests/phpstan/data/TestThroughTraitTest.php
+++ b/tests/phpstan/data/TestThroughTraitTest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Phpstan\Lendable\PHPUnitExtensions\data;
+
+use Lendable\PHPUnitExtensions\TestCase;
+
+class TestThroughTraitTest extends TestCase
+{
+    use TraitWithTest;
+}

--- a/tests/phpstan/data/TraitWithTest.php
+++ b/tests/phpstan/data/TraitWithTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Phpstan\Lendable\PHPUnitExtensions\data;
+
+use PHPUnit\Framework\Attributes\Test;
+
+trait TraitWithTest
+{
+    #[Test]
+    public function loose_mock(): void
+    {
+        $this->createMock(\ArrayAccess::class);
+    }
+}

--- a/tests/rector/Rector/EnforceDisableReturnValueGenerationForTestDoublesRectorTest.php
+++ b/tests/rector/Rector/EnforceDisableReturnValueGenerationForTestDoublesRectorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Rector\Lendable\PHPUnitExtensions\Rector;
 
 use Lendable\PHPUnitExtensions\Rector\EnforceDisableReturnValueGenerationForTestDoublesRector;
+use Lendable\PHPUnitExtensions\StrictMocking;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
@@ -12,6 +13,8 @@ use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 #[CoversClass(EnforceDisableReturnValueGenerationForTestDoublesRector::class)]
 final class EnforceDisableReturnValueGenerationForTestDoublesRectorTest extends AbstractRectorTestCase
 {
+    use StrictMocking;
+
     public function provideConfigFilePath(): string
     {
         return __DIR__.'/config/configured_rule.php';
@@ -25,6 +28,6 @@ final class EnforceDisableReturnValueGenerationForTestDoublesRectorTest extends 
 
     public static function provideData(): \Iterator
     {
-        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+        return self::yieldFilesFromDirectory(__DIR__.'/Fixture');
     }
 }

--- a/tests/rector/Rector/EnforceDisableReturnValueGenerationForTestDoublesRectorTest.php
+++ b/tests/rector/Rector/EnforceDisableReturnValueGenerationForTestDoublesRectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Rector\Lendable\PHPUnitExtensions\Rector;
+
+use Lendable\PHPUnitExtensions\Rector\EnforceDisableReturnValueGenerationForTestDoublesRector;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+#[CoversClass(EnforceDisableReturnValueGenerationForTestDoublesRector::class)]
+final class EnforceDisableReturnValueGenerationForTestDoublesRectorTest extends AbstractRectorTestCase
+{
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+}

--- a/tests/rector/Rector/Fixture/with_attribute.php.inc
+++ b/tests/rector/Rector/Fixture/with_attribute.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Rector\Lendable\PHPUnitExtensions\Rector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+#[\PHPUnit\Framework\Attributes\DisableReturnValueGenerationForTestDoubles]
+final class WithAttributeTest extends TestCase
+{
+}

--- a/tests/rector/Rector/Fixture/without_attribute.php.inc
+++ b/tests/rector/Rector/Fixture/without_attribute.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Rector\Lendable\PHPUnitExtensions\Rector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class WithoutAttributeTest extends TestCase
+{
+}
+
+?>
+-----
+<?php
+
+namespace Tests\Rector\Lendable\PHPUnitExtensions\Rector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+#[\PHPUnit\Framework\Attributes\DisableReturnValueGenerationForTestDoubles]
+final class WithoutAttributeTest extends TestCase
+{
+}
+
+?>

--- a/tests/rector/Rector/config/configured_rule.php
+++ b/tests/rector/Rector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Lendable\PHPUnitExtensions\Rector\EnforceDisableReturnValueGenerationForTestDoublesRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(EnforceDisableReturnValueGenerationForTestDoublesRector::class);
+};

--- a/tests/unit/StrictMockingTest.php
+++ b/tests/unit/StrictMockingTest.php
@@ -24,7 +24,7 @@ final class StrictMockingTest extends TestCase
 
             public function exercise(): void
             {
-                $mock = $this->createMock(ExampleInterface::class);
+                $mock = $this->createStrictMock(ExampleInterface::class);
                 $mock->method('bar')->willReturn(42);
 
                 $mock->foo();


### PR DESCRIPTION
See https://github.com/sebastianbergmann/phpunit/issues/5688 and https://github.com/sebastianbergmann/phpunit/issues/5691.

Draft PR to swap up the implementation to requiring `createMock` to be `createStrictMock`.

## TODO

- [x] Update logic to use a non-overriding method
- [x] Update PHPStan rule to ban any call into `TestCase::createMock` (and probably a bunch of other methods)
- [x] Add Rector to migrate and enforce using `DisableReturnValueGenerationForTestDoubles` attribute from https://github.com/sebastianbergmann/phpunit/pull/5696