### PR TITLE
Fix only unit tests being run in `composer ci`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     "scripts": {
         "ci": [
             "@static-analysis",
-            "@tests:unit"
+            "@tests"
         ],
         "code-style:check": [
             "PHP_CS_FIXER_FUTURE_MODE=1 php-cs-fixer fix --dry-run --diff --ansi"
@@ -85,12 +85,9 @@
             "@rector:check"
         ],
         "tests": [
-            "@tests:unit",
+            "@phpunit:unit",
             "@phpunit:phpstan",
             "@phpunit:rector"
-        ],
-        "tests:unit": [
-            "@phpunit:unit"
         ]
     }
 }


### PR DESCRIPTION
GitHub Actions are calling `composer tests` so the other test suites are being enforced.