### PR TITLE
Don't add `DisableReturnValueGenerationForTestDoubles` to abstract classes via Rector

### DIFF
--- a/src/Rector/EnforceDisableReturnValueGenerationForTestDoublesRector.php
+++ b/src/Rector/EnforceDisableReturnValueGenerationForTestDoublesRector.php
@@ -62,6 +62,10 @@ final class EnforceDisableReturnValueGenerationForTestDoublesRector extends Abst
             return null;
         }
 
+        if ($node->isAbstract()) {
+            return null;
+        }
+
         if ($this->attributeAnalyzer->hasPhpAttribute($node, DisableReturnValueGenerationForTestDoubles::class)) {
             return null;
         }

--- a/tests/rector/Rector/Fixture/abstract_without_attribute.php.inc
+++ b/tests/rector/Rector/Fixture/abstract_without_attribute.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tests\Rector\Lendable\PHPUnitExtensions\Rector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractWithoutAttributeTest extends TestCase
+{
+}


### PR DESCRIPTION
The attribute must be placed on the concrete class to have any effect so this is harmless but redundant and confusing.