### PR TITLE
chore(DEVOPS-10688): bump create-github-app-token to v3 and rename app-id to client-id

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-24.04
     name: Release Automation
     steps:
-      - uses: actions/create-github-app-token@af35edadc00be37caa72ed9f3e6d5f7801bfdf09 # v1
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: generate-token
         with:
-          app-id: ${{ secrets.LENDABOT_APP_ID }}
+          client-id: ${{ secrets.LENDABOT_APP_ID }}
           private-key: ${{ secrets.LENDABOT_APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4


### PR DESCRIPTION
# [DEVOPS-10688](https://lendable-uk.atlassian.net/browse/DEVOPS-10688)

## Changes
- Bump `actions/create-github-app-token` to v3 (`bcd2ba4`) and rename the deprecated `app-id` input to `client-id`. The previous pin predates the `client-id` input, so the rename requires v3.
- The value is unchanged — GitHub accepts your existing App ID as the JWT issuer under either key, so authentication is unaffected.

## ⚠️ v3 breaking changes — please verify before merging
- Runs on **Node 24**; self-hosted runners need **Actions Runner ≥ v2.327.1**.
- If this workflow uses `HTTP_PROXY`/`HTTPS_PROXY`, set `NODE_USE_ENV_PROXY=1` on the step.

Part of the org-wide `app-id`→`client-id` cleanup (DEVOPS-10688). Opened as draft pending team review.

[DEVOPS-10688]: https://lendable-uk.atlassian.net/browse/DEVOPS-10688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ