### PR TITLE
docs: document Rector rule in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,16 +68,3 @@ return static function (RectorConfig $rector): void {
     $rector->rule(EnforceDisableReturnValueGenerationForTestDoublesRector::class);
 };
 ```
-
-Running Rector will then add the attribute where it is missing:
-
-```diff
- namespace Tests\Foo;
-
- use PHPUnit\Framework\TestCase;
-
-+#[\PHPUnit\Framework\Attributes\DisableReturnValueGenerationForTestDoubles]
- class FooTest extends TestCase
- {
- }
-```

--- a/README.md
+++ b/README.md
@@ -50,3 +50,34 @@ lendable_phpunit:
         pardoned:
             - Foo\Bar\MyTest
 ```
+
+## Rector
+
+A [Rector](https://getrector.com/) rule is provided to automate adopting strict mocking across a test suite.
+
+`Lendable\PHPUnitExtensions\Rector\EnforceDisableReturnValueGenerationForTestDoublesRector` adds PHPUnit's `#[DisableReturnValueGenerationForTestDoubles]` attribute to test classes that do not already have it. Abstract classes are skipped, since the attribute only has an effect when placed on the concrete test class.
+
+Register the rule in your Rector configuration:
+
+```php
+use Lendable\PHPUnitExtensions\Rector\EnforceDisableReturnValueGenerationForTestDoublesRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rector): void {
+    // ...
+    $rector->rule(EnforceDisableReturnValueGenerationForTestDoublesRector::class);
+};
+```
+
+Running Rector will then add the attribute where it is missing:
+
+```diff
+ namespace Tests\Foo;
+
+ use PHPUnit\Framework\TestCase;
+
++#[\PHPUnit\Framework\Attributes\DisableReturnValueGenerationForTestDoubles]
+ class FooTest extends TestCase
+ {
+ }
+```

--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Register the rule in your Rector configuration:
 use Lendable\PHPUnitExtensions\Rector\EnforceDisableReturnValueGenerationForTestDoublesRector;
 use Rector\Config\RectorConfig;
 
-return static function (RectorConfig $rector): void {
+return RectorConfig::configure()
     // ...
-    $rector->rule(EnforceDisableReturnValueGenerationForTestDoublesRector::class);
-};
+    ->withRules([EnforceDisableReturnValueGenerationForTestDoublesRector::class]);
 ```
+
+With the closure-style configuration, register it via `$rectorConfig->rule(EnforceDisableReturnValueGenerationForTestDoublesRector::class)`.


### PR DESCRIPTION
Adds a `## Rector` section to the README documenting `EnforceDisableReturnValueGenerationForTestDoublesRector` and its registration in `rector.php`.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)