### PR TITLE
ci: add actionlint workflow checks

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,27 @@ on:
       - "main"
 
 jobs:
+  lint-actionlint:
+    name: "Lint workflows"
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7
+        with:
+          show-progress: false
+
+      - name: "Install actionlint"
+        id: actionlint
+        run: bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
+
+      - name: "Run actionlint"
+        run: |
+          echo "::add-matcher::.github/actionlint-matcher.json"
+          trap 'echo "::remove-matcher owner=actionlint::"' EXIT
+          "${{ steps.actionlint.outputs.executable }}" -color
+
   ci:
     name: "Execute (PHP ${{ matrix.php-version }} @ ${{ matrix.dependencies }} deps)"
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
## Stack

Follow-up Zizmor PR: https://github.com/Lendable/phpunit-extensions/pull/169

## Summary

- lint GitHub Actions workflows with Actionlint in CI
- add a problem matcher for inline workflow diagnostics
- pin the Actionlint release used by CI

## Verification

- actionlint -color
- git diff --check