### PR TITLE
ci: add zizmor workflow security audits

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,27 @@ on:
       - "main"
 
 jobs:
+  lint-actionlint:
+    name: "Lint workflows"
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7
+        with:
+          show-progress: false
+
+      - name: "Install actionlint"
+        id: actionlint
+        run: bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
+
+      - name: "Run actionlint"
+        run: |
+          echo "::add-matcher::.github/actionlint-matcher.json"
+          trap 'echo "::remove-matcher owner=actionlint::"' EXIT
+          "${{ steps.actionlint.outputs.executable }}" -color
+
   ci:
     name: "Execute (PHP ${{ matrix.php-version }} @ ${{ matrix.dependencies }} deps)"
     runs-on: "ubuntu-latest"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,8 @@ on:
     branches:
       - "main"
 
+permissions: {}
+
 jobs:
   lint-actionlint:
     name: "Lint workflows"
@@ -21,6 +23,7 @@ jobs:
       - name: "Checkout"
         uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: "Install actionlint"
@@ -28,14 +31,18 @@ jobs:
         run: bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
 
       - name: "Run actionlint"
+        env:
+          ACTIONLINT: "${{ steps.actionlint.outputs.executable }}"
         run: |
           echo "::add-matcher::.github/actionlint-matcher.json"
           trap 'echo "::remove-matcher owner=actionlint::"' EXIT
-          "${{ steps.actionlint.outputs.executable }}" -color
+          "$ACTIONLINT" -color
 
   ci:
     name: "Execute (PHP ${{ matrix.php-version }} @ ${{ matrix.dependencies }} deps)"
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -52,6 +59,7 @@ jobs:
       - name: "Checkout"
         uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: "Install PHP"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,8 @@ jobs:
         id: generate-token
         with:
           client-id: ${{ secrets.LENDABOT_APP_ID }}
+          permission-contents: write
+          permission-pull-requests: write
           private-key: ${{ secrets.LENDABOT_APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -22,20 +22,10 @@ jobs:
           persist-credentials: false
           show-progress: false
 
-      - name: "Install Zizmor"
-        shell: bash
-        env:
-          ZIZMOR_SHA256: dd96df044a6e8538d5f423790f453bdd03d49e5b2bcc38214acc41a2f1297839
-          ZIZMOR_VERSION: 1.29.0
-        run: |
-          set -euo pipefail
-
-          archive="$RUNNER_TEMP/zizmor.tar.gz"
-          curl -fsSL "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-x86_64-unknown-linux-gnu.tar.gz" -o "$archive"
-          echo "${ZIZMOR_SHA256}  $archive" | sha256sum --check
-          tar -xzf "$archive" -C "$RUNNER_TEMP"
-
       - name: "Run Zizmor"
-        env:
-          GH_TOKEN: "${{ github.token }}"
-        run: '"$RUNNER_TEMP/zizmor" --format github .'
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          inputs: "."
+          version: "1.29.0"
+          advanced-security: false
+          annotations: true

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -23,10 +23,13 @@ jobs:
           show-progress: false
 
       - name: "Install Zizmor"
+        shell: bash
         env:
           ZIZMOR_SHA256: dd96df044a6e8538d5f423790f453bdd03d49e5b2bcc38214acc41a2f1297839
           ZIZMOR_VERSION: 1.29.0
         run: |
+          set -euo pipefail
+
           archive="$RUNNER_TEMP/zizmor.tar.gz"
           curl -fsSL "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-x86_64-unknown-linux-gnu.tar.gz" -o "$archive"
           echo "${ZIZMOR_SHA256}  $archive" | sha256sum --check

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,30 @@
+name: "Zizmor"
+
+on:
+  merge_group:
+  pull_request:
+  push:
+    branches:
+      - "main"
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: "Audit workflows"
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7
+        with:
+          persist-credentials: false
+          show-progress: false
+
+      - name: "Run Zizmor"
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: false
+          annotations: true
+          version: v1.29.0

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -22,9 +22,17 @@ jobs:
           persist-credentials: false
           show-progress: false
 
+      - name: "Install Zizmor"
+        env:
+          ZIZMOR_SHA256: dd96df044a6e8538d5f423790f453bdd03d49e5b2bcc38214acc41a2f1297839
+          ZIZMOR_VERSION: 1.29.0
+        run: |
+          archive="$RUNNER_TEMP/zizmor.tar.gz"
+          curl -fsSL "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/zizmor-x86_64-unknown-linux-gnu.tar.gz" -o "$archive"
+          echo "${ZIZMOR_SHA256}  $archive" | sha256sum --check
+          tar -xzf "$archive" -C "$RUNNER_TEMP"
+
       - name: "Run Zizmor"
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
-        with:
-          advanced-security: false
-          annotations: true
-          version: v1.29.0
+        env:
+          GH_TOKEN: "${{ github.token }}"
+        run: '"$RUNNER_TEMP/zizmor" --format github .'


### PR DESCRIPTION
## Stack

This PR is stacked on the Actionlint PR: https://github.com/Lendable/phpunit-extensions/pull/168

## Summary

- run Zizmor v1.29.0 through the allow-listed official `zizmorcore/zizmor-action`
- use least-privilege permissions and disable checkout credential persistence
- narrow the release GitHub App token permissions

## Verification

- actionlint -color
- local Zizmor 1.29.0 static audit: no findings
- official Zizmor action CI audit
- git diff --check
